### PR TITLE
Added libclang_rt.builtins-arm.a.a symlink so clang automatically links.

### DIFF
--- a/armv6m-cortex-m0plus.rb
+++ b/armv6m-cortex-m0plus.rb
@@ -135,6 +135,8 @@ class Armv6mCortexM0plus < Formula
       system "cp libcompiler_rt.a #{prefix}/armv6m-none-eabi/cortex-m0plus/lib/"
       ln_s "#{prefix}/armv6m-none-eabi/cortex-m0plus/lib/libcompiler_rt.a",
            "#{prefix}/armv6m-none-eabi/cortex-m0plus/lib/libclang_rt.builtins-armv6m.a.a"
+      ln_s "#{prefix}/armv6m-none-eabi/cortex-m0plus/lib/libcompiler_rt.a",
+           "#{prefix}/armv6m-none-eabi/cortex-m0plus/lib/libclang_rt.builtins-arm.a.a"
     end
   end
 

--- a/armv7em-cortex-m4.rb
+++ b/armv7em-cortex-m4.rb
@@ -115,6 +115,8 @@ class Armv7emCortexM4 < Formula
       system "cp libcompiler_rt.a #{prefix}/armv7em-none-eabi/cortex-m4/lib/"
       ln_s "#{prefix}/armv7em-none-eabi/cortex-m4/lib/libcompiler_rt.a",
            "#{prefix}/armv7em-none-eabi/cortex-m4/lib/libclang_rt.builtins-armv7em.a.a"
+      ln_s "#{prefix}/armv7em-none-eabi/cortex-m4/lib/libcompiler_rt.a",
+           "#{prefix}/armv7em-none-eabi/cortex-m4/lib/libclang_rt.builtins-arm.a.a"
     end
   end
 

--- a/armv7em-cortex-m4f.rb
+++ b/armv7em-cortex-m4f.rb
@@ -116,6 +116,8 @@ class Armv7emCortexM4f < Formula
       system "cp libcompiler_rt.a #{prefix}/armv7em-none-eabi/cortex-m4f/lib/"
       ln_s "#{prefix}/armv7em-none-eabi/cortex-m4f/lib/libcompiler_rt.a",
            "#{prefix}/armv7em-none-eabi/cortex-m4f/lib/libclang_rt.builtins-armv7em.a.a"
+      ln_s "#{prefix}/armv7em-none-eabi/cortex-m4f/lib/libcompiler_rt.a",
+           "#{prefix}/armv7em-none-eabi/cortex-m4f/lib/libclang_rt.builtins-arm.a.a"
     end
   end
 

--- a/armv7m-cortex-m3.rb
+++ b/armv7m-cortex-m3.rb
@@ -115,6 +115,8 @@ class Armv7mCortexM3 < Formula
       system "cp libcompiler_rt.a #{prefix}/armv7m-none-eabi/cortex-m3/lib/"
       ln_s "#{prefix}/armv7m-none-eabi/cortex-m3/lib/libcompiler_rt.a",
            "#{prefix}/armv7m-none-eabi/cortex-m3/lib/libclang_rt.builtins-armv7m.a.a"
+      ln_s "#{prefix}/armv7m-none-eabi/cortex-m3/lib/libcompiler_rt.a",
+           "#{prefix}/armv7m-none-eabi/cortex-m3/lib/libclang_rt.builtins-arm.a.a"
     end
   end
 


### PR DESCRIPTION
This eventually can be removed once https://bugs.llvm.org/show_bug.cgi?id=34578 is fixed.