### PR TITLE
Add python and libguile dependencies to arm-none-eabi-gdb for non macos targets.

### DIFF
--- a/arm-none-eabi-gdb.rb
+++ b/arm-none-eabi-gdb.rb
@@ -10,6 +10,10 @@ class ArmNoneEabiGdb <Formula
   depends_on 'libmpc'
   depends_on 'readline'
 
+  # Linux dependencies.
+  depends_on 'python@2' unless OS.mac?
+  depends_on 'guile' unless OS.mac?
+
   def install
     system "./configure", "--prefix=#{prefix}", "--target=arm-none-eabi",
                 "--with-gmp=#{Formulary.factory('gmp').prefix}",


### PR DESCRIPTION
Most of these recipes work on linux, but in the past, I have had to use an alternate tap to get arm-none-eabi-gdb on linux. The issue seems to be that mac automatically provides dependencies for python and libguile. 

This PR adds the two missing dependencies for non mac targets.

I do not have a mac right now to test this on. Before accepting this PR, please test it still works with mac (it should).